### PR TITLE
Add Django Rest Framework

### DIFF
--- a/webet/events/serializers.py
+++ b/webet/events/serializers.py
@@ -1,0 +1,10 @@
+from rest_framework import serializers
+from .models import Event
+
+
+class EventSerializer(serializers.ModelSerializer):
+    tags = serializers.StringRelatedField(many=True)
+
+    class Meta:
+        model = Event
+        fields = ('id', 'name', 'start_time', 'end_time', 'tags')

--- a/webet/events/urls.py
+++ b/webet/events/urls.py
@@ -1,0 +1,10 @@
+from django.urls import path
+
+from . import views
+
+app_name = 'events'
+urlpatterns = [
+    path('', views.EventView.as_view({'get': 'list'}), name='list'),
+    path('<int:pk>/',
+         views.EventView.as_view({'get': 'retrieve'}), name='get'),
+]

--- a/webet/events/views.py
+++ b/webet/events/views.py
@@ -1,3 +1,8 @@
-from django.shortcuts import render
+from rest_framework import viewsets
 
-# Create your views here.
+from events.serializers import EventSerializer
+from events.models import Event
+
+class EventView(viewsets.ModelViewSet):
+    serializer_class = EventSerializer
+    queryset = Event.objects.all()

--- a/webet/players/serializers.py
+++ b/webet/players/serializers.py
@@ -1,0 +1,9 @@
+from rest_framework import serializers
+from .models import Player
+
+class PlayerSerializer(serializers.ModelSerializer):
+    tags = serializers.StringRelatedField(many=True)
+
+    class Meta:
+        model = Player
+        fields = ('id', 'first_name', 'last_name', 'prefix', 'suffix', 'version', 'tags')

--- a/webet/players/views.py
+++ b/webet/players/views.py
@@ -1,37 +1,9 @@
-from django.http import HttpResponse, JsonResponse
-from django.views.decorators.http import require_http_methods
+from rest_framework import viewsets
 
+from players.serializers import PlayerSerializer
 from players.models import Player
 
 
-@require_http_methods(["GET"])
-def player_list(request):
-
-    players = Player.objects.all()
-
-    response = {
-        'players': [
-            {
-                'first_name': player.first_name,
-                'last_name': player.last_name
-            } for player in players
-        ],
-        'has_more': False
-    }
-    return JsonResponse(response)
-
-
-def player_create(request):
-    return HttpResponse("Success")
-
-
-def player_read(request, player_id):
-    return HttpResponse("Success")
-
-
-def player_update(request, player_id):
-    return HttpResponse("Success")
-
-
-def player_delete(request, player_id):
-    return HttpResponse("Success")
+class PlayerView(viewsets.ModelViewSet):
+    serializer_class = PlayerSerializer
+    queryset = Player.objects.all()

--- a/webet/requirements.txt
+++ b/webet/requirements.txt
@@ -1,4 +1,6 @@
 asgiref==3.3.1
 Django==3.1.7
+django-cors-headers==3.7.0
+djangorestframework==3.12.2
 pytz==2021.1
 sqlparse==0.4.1

--- a/webet/webet/settings.py
+++ b/webet/webet/settings.py
@@ -41,6 +41,8 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'corsheaders',
+    'rest_framework'
 ]
 
 MIDDLEWARE = [
@@ -51,6 +53,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
 ]
 
 ROOT_URLCONF = 'webet.urls'
@@ -122,3 +125,7 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/3.1/howto/static-files/
 
 STATIC_URL = '/static/'
+
+CORS_ORIGIN_WHITELIST = [
+    'http://localhost:3000'
+]

--- a/webet/webet/urls.py
+++ b/webet/webet/urls.py
@@ -15,8 +15,16 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path, include
+from rest_framework import routers
+
+from events.views import EventView
+from players.views import PlayerView
+
+router = routers.DefaultRouter()
+router.register(r'events', EventView, 'events')
+router.register(r'players', PlayerView, 'players')
 
 urlpatterns = [
-    path('players/', include('players.urls')),
+    path('api/', include(router.urls)),
     path('admin/', admin.site.urls),
 ]


### PR DESCRIPTION
Adds and sets up the [Django Rest Framework](https://www.django-rest-framework.org/) in the project to help us quickly scaffold out a RESTful API for our models.

Sets up everything needed for REST endpoints for Event model and replaces the setup for the Player model with the Django Rest Framework setup.