### PR TITLE
chore: Fix python path

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
     "editor.rulers": [ 100 ],
-    "python.pythonPath": "/mnt/c/Users/Will/Documents/projects/webet/webet/venv/bin/python3",
+    "python.pythonPath": "venv/bin/python",
     "python.linting.pylintEnabled": true,
     "python.linting.enabled": true,
     "python.analysis.extraPaths": ["./webet"]


### PR DESCRIPTION
The venv python path should be relative to the root of the project, instead of the absolute path to the file, on disk, on my specific machine